### PR TITLE
Fixes in Error Handling when reading time API

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,13 +14,12 @@ time_api = 'http://worldtimeapi.org/api/timezone/Europe/Berlin'
 def fetch_time() -> datetime:
     try:
         response = requests.get(time_api, timeout=30)
+        data = json.loads(response.text)
+        return datetime.datetime.fromisoformat(data['datetime'])
     except Exception as e:
         print('Something went wrong')
         print(e)
-        return datetime.datetime.now()
-    data = json.loads(response.text)
-    time = datetime.datetime.fromisoformat(data['datetime'])
-    return time
+    return datetime.datetime.now()
 
 # Testkommentar
 class Qlocktwo(QMainWindow):


### PR DESCRIPTION
Application crashed while parsing JSON / parsing Date returned from Time API.
Moved JSON parsing into try block to account for this.
We could also improve the error handling to listen for different http status codes but since we just return the default system time whenever a valid time can not be read from the API I think that is not necessary here.